### PR TITLE
Handle cases for risk computation where all nodes are in exclude list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>com.simplymeasured.elasticsearch.plugins</groupId>
     <artifactId>tempest</artifactId>
-    <version>2.2.1-ES${elasticsearch.version}</version>
+    <version>2.2.2-ES${elasticsearch.version}</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/simplymeasured/elasticsearch/plugins/tempest/balancer/model/ModelCluster.kt
+++ b/src/main/java/com/simplymeasured/elasticsearch/plugins/tempest/balancer/model/ModelCluster.kt
@@ -191,7 +191,7 @@ class ModelCluster (
      * Note this is currently defined in terms of the size of the most over-capacity node in the cluster
      */
     fun calculateRisk(): Double = destinationNodes
-            .collect { it.calculateNormalizedNodeUsage() }
+            .map { it.calculateNormalizedNodeUsage() }
             .max()
             ?: 0.0
 

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -24,7 +24,7 @@
 
 classname=com.simplymeasured.elasticsearch.plugins.tempest.TempestPlugin
 description=The Tempest Balancer Plugins attempts to balance a cluster by shard size
-version=2.2.1
+version=2.2.2
 name=tempest
 site=false
 jvm=true


### PR DESCRIPTION
This caused a NoSuchElementException when calculating risk. The bug got introduced in a recent change where, instead of using optional kotlin collection `max`, EC `max` was getting used.

@kennycason @aewhite please have a look.